### PR TITLE
Fix compilation on MSVC.

### DIFF
--- a/thread_pool.hpp
+++ b/thread_pool.hpp
@@ -339,7 +339,7 @@ private:
         while (running)
         {
             std::function<void()> task;
-            if (!paused and pop_task(task))
+            if (!paused && pop_task(task))
             {
                 task();
                 tasks_total--;


### PR DESCRIPTION
Compilation with MSVC fails because of the 'and' keyword, after replacing it with '&&' it works.