### PR TITLE
Fix a race in check_pausing test.

### DIFF
--- a/thread_pool_test.cpp
+++ b/thread_pool_test.cpp
@@ -1095,6 +1095,7 @@ int main()
     print_header("Testing that matrix operations produce the expected results:");
     check_matrix();
 
+    int exit_code = 0;
     if (tests_failed == 0)
     {
         print_header("SUCCESS: Passed all " + std::to_string(tests_succeeded) + " checks!", '+');
@@ -1106,7 +1107,8 @@ int main()
     {
         print_header("FAILURE: Passed " + std::to_string(tests_succeeded) + " checks, but failed " + std::to_string(tests_failed) + "!", '+');
         dual_println("\nPlease submit a bug report at https://github.com/bshoshany/thread-pool/issues including the exact specifications of your system (OS, CPU, compiler, etc.) and the generated log file.");
+        exit_code = 1;
     }
 
-    return 0;
+    return exit_code;
 }


### PR DESCRIPTION
**Describe the changes**

Two changes:

1. Use exit code 1 if test has failures.
    - So I can use a script to repeatedly run the test many times and stop when there's any failure.
2. Fix a race in check_pause
    - The cause is describe in comment.
    - The race is found after I changed the queue to a simple concurrent queue which supports `wait_and_pop`. Full changes on my fork's [master branch](https://github.com/cyfdecyf/thread-pool/blob/master/thread_pool.hpp).

Thanks for this nice project. I'm new to concurrency support in C++, this project is clean and easy to understand, which motivates me to hack for my own requirements.

**Testing**

Have you tested the new code using the provided automated test program `thread_pool_test.cpp` and/or performed any other tests to ensure that it works correctly? If so, please provide information about the test system(s):

* CPU model, architecture, # of cores and threads: Intel Core i5-8259U Processor
* Operating system: macOS
* Name and version of C++ compiler: Apple clang version 13.1.6 (clang-1316.0.21.2.5)
* Full command used for compiling, including all compiler flags: I'm using [CMakeLists.txt](https://github.com/cyfdecyf/thread-pool/blob/master/CMakeLists.txt).