### PR TITLE
check_task_monitoring: check after sleep.

### DIFF
--- a/thread_pool_test.cpp
+++ b/thread_pool_test.cpp
@@ -370,21 +370,25 @@ void check_task_monitoring()
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     dual_println("After submission, should have: ", n * 3, " tasks total, ", n, " tasks running, ", n * 2, " tasks queued...");
     check(pool.get_tasks_total() == n * 3 && pool.get_tasks_running() == n && pool.get_tasks_queued() == n * 2);
+
     for (ui32 i = 0; i < n; i++)
         release[i] = true;
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     dual_println("After releasing ", n, " tasks, should have: ", n * 2, " tasks total, ", n, " tasks running, ", n, " tasks queued...");
+    check(pool.get_tasks_total() == n * 2 && pool.get_tasks_running() == n && pool.get_tasks_queued() == n);
+
     for (ui32 i = n; i < n * 2; i++)
         release[i] = true;
-    check(pool.get_tasks_total() == n * 2 && pool.get_tasks_running() == n && pool.get_tasks_queued() == n);
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     dual_println("After releasing ", n, " more tasks, should have: ", n, " tasks total, ", n, " tasks running, ", 0, " tasks queued...");
     check(pool.get_tasks_total() == n && pool.get_tasks_running() == n && pool.get_tasks_queued() == 0);
+
     for (ui32 i = n * 2; i < n * 3; i++)
         release[i] = true;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     dual_println("After releasing the final ", n, " tasks, should have: ", 0, " tasks total, ", 0, " tasks running, ", 0, " tasks queued...");
     check(pool.get_tasks_total() == 0 && pool.get_tasks_running() == 0 && pool.get_tasks_queued() == 0);
+
     dual_println("Resetting pool to ", std::thread::hardware_concurrency(), " threads.");
     pool.reset(std::thread::hardware_concurrency());
 }


### PR DESCRIPTION
**Describe the changes**

In `check_task_monitoring`, the check pattern should be

1. release
2. sleep
3. print
4. check

There's one test which has release and check immediately following which can result test failure.

Also added some blank lines to make the pattern easier to spot.

**Testing**

Have you tested the new code using the provided automated test program `thread_pool_test.cpp` and/or performed any other tests to ensure that it works correctly? If so, please provide information about the test system(s):

* CPU model, architecture, # of cores and threads: Intel Core i5-8259U Processor, 4 core 8 threads
* Operating system: macOS, Monterey
* Name and version of C++ compiler: Apple clang version 13.1.6 (clang-1316.0.21.2.5)
* Full command used for compiling, including all compiler flags: I'm using [CMakeLists.txt](https://github.com/cyfdecyf/thread-pool/blob/master/CMakeLists.txt).