### PR TITLE
Add thread accessor

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -292,6 +292,14 @@ public:
         waiting = false;
     }
 
+    /**
+     * @brief Return a reference to the thread with a given index. Manipulating the returned thread may break the semantics of the pool. This function is primarily intended to access the native_handle for implementing platform-specific behaviour (e.g. setting thread names).
+     */
+    [[nodiscard]] std::thread& get_thread(size_t thread_idx)
+    {
+        return threads[thread_idx];
+    }
+
     // ===========
     // Public data
     // ===========


### PR DESCRIPTION
**Describe the changes**

This pull request adds an accessor for individual OS threads.
I realize that this breaks the encapsulation, and it's not a great solution, but I can think of no other good way to do what we need to do (which is accessing the underlying native handle in order to e.g. set a thread name or change the priority). One option would be to submit work to do it on the current thread (`this_thread`), but that seems incredibly hacky and failure-prone.

One question would be whether the precondition that `thread_idx` is valid should be checked somehow, but I didn't see other assertions of this kind in the code base.

**Testing**

Given the extent of the code it doesn't seem like there is much to test.