### PR TITLE
Enable multi_future::get for void multi futures

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -49,16 +49,27 @@ public:
     multi_future(const size_t num_futures_ = 0) : f(num_futures_) {}
 
     /**
-     * @brief Get the results from all the futures stored in this multi_future object.
+     * @brief Get the results from all the futures stored in this multi_future object, re-throwing any stored exceptions.
      *
      * @return A vector containing the results.
      */
-    [[nodiscard]] std::vector<T> get()
+    template<typename V = T>
+    [[nodiscard]] std::enable_if_t<!std::is_same_v<void, V>, std::vector<T>> get()
     {
         std::vector<T> results(f.size());
         for (size_t i = 0; i < f.size(); ++i)
             results[i] = f[i].get();
         return results;
+    }
+
+    /**
+     * @brief Get the results from all the void futures stored in this multi_future object, re-throwing any stored exceptions.
+     */
+    template<typename V = T>
+    std::enable_if_t<std::is_same_v<void, V>, void> get()
+    {
+        for (size_t i = 0; i < f.size(); ++i)
+            f[i].get();
     }
 
     /**


### PR DESCRIPTION
**Describe the changes**

This PR adds a specialization of `multi_future::get` which allows using it on `void` multi-futures. Without this change, as far as I can tell, it's *impossible to catch exceptions thrown by loop bodies in the common `parallelize_loop` case* where the body does not return a value. In fact, any such exceptions get silently consumed and the execution of that parallel part of the loop is stopped. That's a pretty significant usability issue, and can be initially difficult to debug.
With this PR, the user can at least call `get` on the multi-future to ensure that an exception is forwarded.

**Testing**

We tested this in our code base. Of course it would be easy to add tests for it in the test program as well, but I didn't want to invest that effort before knowing whether the PR would be accepted.

**Additional information**

Another option would be to change the existing `wait` to use `get`. That would reduce the foot-gun potential, but would not be as close to the `std::future` API. On the other hand, I'm not sure if the "just silently ignore exceptions" use case really needs to be supported.