### PR TITLE
fix: keep all `tasks_total` member value changes safely wrapped inside the same mutex-protected zone.

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -428,8 +428,8 @@ public:
         {
             const std::scoped_lock tasks_lock(tasks_mutex);
             tasks.push(task_function);
+            ++tasks_total;
         }
-        ++tasks_total;
         task_available_cv.notify_one();
     }
 
@@ -602,6 +602,8 @@ private:
 
     /**
      * @brief A condition variable used to notify worker() that a new task has become available.
+     *
+     * The accompanying mutex is `tasks_mutex`.
      */
     std::condition_variable task_available_cv = {};
 
@@ -622,6 +624,11 @@ private:
 
     /**
      * @brief A mutex to synchronize access to the task queue by different threads.
+     *
+     * This mutex presides over these variables:
+     * - tasks                     : all r/w access of course
+     * - tasks_total               : write/change operations only
+     * - task_available_cv.wait()  : waiting for signal that tasks queue has been updated
      */
     mutable std::mutex tasks_mutex = {};
 


### PR DESCRIPTION
**Describe the changes**

fix: keep all `tasks_total` member value changes safely wrapped inside the same mutex-protected zone. The design assumes `tasks_total` is always in sync with the actual state of the queue+running tasks (or APIs like `get_tasks_running()` would be lying to the caller at some point in time) and having this one inside the mutex-protected zone keeps that assumption intact.

---

From: SHA-1: 12253b6610ed2f237660abeb91446beab27f63d1

* fixes:
- push_task(): document which (member) variables are under which mutex' overwatch and make sure the code matches this.
  + Case in point: the `tasks_total` counter MUST be kept in sync with the actual `tasks` queue size hence it must be managed by the same mutex, or you will have situations where `get_tasks_running()` is lying to you and we CANNOT afford that.
  + Second case in point: [to-be-submitted]

---

**Testing**

This was tested as part of a larger work (other PRs are forthcoming shortly) after hunting down shutdown issues (application lockups, etc.) in a large application.

Tested this code via your provided test code rig; see my own fork and the referenced commits which point into there.

Tested on AMD Ryzen 3700X, 128GB RAM, latest Win10/64, latest MSVC2019 dev environment. Using in-house project files which use a (in-house) standardized set of optimizations. 

**Additional information**

**TBD**

The patches are hopefully largely self-explanatory. Where deemed useful, the original commit messages from the dev fork have been referenced and included.
