### PR TITLE
fixes MSVC (MSVC2019, ...) errors when projects are used which have _CRT_SECURE_NO_WARNINGS already set as part of the default build settings

### DIFF
--- a/BS_thread_pool_light_test.cpp
+++ b/BS_thread_pool_light_test.cpp
@@ -9,7 +9,7 @@
  */
 
 // Get rid of annoying MSVC warning.
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
@@ -32,6 +32,10 @@
 
 // Include the header file for the thread pool library.
 #include "BS_thread_pool_light.hpp"
+
+// fix for MSVC/WIN32:
+#undef min
+#undef max
 
 // ================
 // Global variables

--- a/BS_thread_pool_test.cpp
+++ b/BS_thread_pool_test.cpp
@@ -9,7 +9,7 @@
  */
 
 // Get rid of annoying MSVC warning.
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
@@ -37,6 +37,10 @@
 
 // Include the header file for the thread pool library.
 #include "BS_thread_pool.hpp"
+
+// fix for MSVC/WIN32:
+#undef min
+#undef max
 
 // ================
 // Global variables


### PR DESCRIPTION
fixes for MSVC (MSVC2019, ...) and when projects are used which have _CRT_SECURE_NO_WARNINGS already set as part of the default build settings.


---

**Testing**

This was tested as part of a larger work (other PRs are forthcoming shortly) after hunting down shutdown issues (application lockups, etc.) in a large application.

Tested this code via your provided test code rig; see my own fork and the referenced commits which point into there.

Tested on AMD Ryzen 3700X, 128GB RAM, latest Win10/64, latest MSVC2019 dev environment. Using in-house project files which use a (in-house) standardized set of optimizations. 

**Additional information**

**TBD**

The patches are hopefully largely self-explanatory. Where deemed useful, the original commit messages from the dev fork have been referenced and included.
