### PR TITLE
test code: stick to the adagio: one statement per line. Saves hassle when debugging as setting debugger breakpoints is a line-oriented dev activity

### DIFF
--- a/BS_thread_pool_light_test.cpp
+++ b/BS_thread_pool_light_test.cpp
@@ -194,14 +194,18 @@ void check_push_task()
     println("Checking that push_task() works for a function with no arguments or return value...");
     {
         bool flag = false;
-        pool.push_task([&flag] { flag = true; });
+        pool.push_task([&flag] {
+			flag = true;
+		});
         pool.wait_for_tasks();
         check(flag);
     }
     println("Checking that push_task() works for a function with one argument and no return value...");
     {
         bool flag = false;
-        pool.push_task([](bool* flag_) { *flag_ = true; }, &flag);
+        pool.push_task([](bool* flag_) {
+			*flag_ = true;
+		}, &flag);
         pool.wait_for_tasks();
         check(flag);
     }
@@ -209,7 +213,9 @@ void check_push_task()
     {
         bool flag1 = false;
         bool flag2 = false;
-        pool.push_task([](bool* flag1_, bool* flag2_) { *flag1_ = *flag2_ = true; }, &flag1, &flag2);
+        pool.push_task([](bool* flag1_, bool* flag2_) {
+			*flag1_ = *flag2_ = true;
+		}, &flag1, &flag2);
         pool.wait_for_tasks();
         check(flag1 && flag2);
     }
@@ -223,20 +229,26 @@ void check_submit()
     println("Checking that submit() works for a function with no arguments or return value...");
     {
         bool flag = false;
-        pool.submit([&flag] { flag = true; }).wait();
+        pool.submit([&flag] { 
+			flag = true; 
+		}).wait();
         check(flag);
     }
     println("Checking that submit() works for a function with one argument and no return value...");
     {
         bool flag = false;
-        pool.submit([](bool* flag_) { *flag_ = true; }, &flag).wait();
+        pool.submit([](bool* flag_) { 
+			*flag_ = true; 
+		}, &flag).wait();
         check(flag);
     }
     println("Checking that submit() works for a function with two arguments and no return value...");
     {
         bool flag1 = false;
         bool flag2 = false;
-        pool.submit([](bool* flag1_, bool* flag2_) { *flag1_ = *flag2_ = true; }, &flag1, &flag2).wait();
+        pool.submit([](bool* flag1_, bool* flag2_) { 
+			*flag1_ = *flag2_ = true; 
+		}, &flag1, &flag2).wait();
         check(flag1 && flag2);
     }
     println("Checking that submit() works for a function with no arguments and a return value...");

--- a/BS_thread_pool_test.cpp
+++ b/BS_thread_pool_test.cpp
@@ -245,14 +245,18 @@ void check_push_task()
     dual_println("Checking that push_task() works for a function with no arguments or return value...");
     {
         bool flag = false;
-        pool.push_task([&flag] { flag = true; });
+        pool.push_task([&flag] {
+			flag = true;
+		});
         pool.wait_for_tasks();
         check(flag);
     }
     dual_println("Checking that push_task() works for a function with one argument and no return value...");
     {
         bool flag = false;
-        pool.push_task([](bool* flag_) { *flag_ = true; }, &flag);
+        pool.push_task([](bool* flag_) {
+			*flag_ = true;
+		}, &flag);
         pool.wait_for_tasks();
         check(flag);
     }
@@ -260,7 +264,9 @@ void check_push_task()
     {
         bool flag1 = false;
         bool flag2 = false;
-        pool.push_task([](bool* flag1_, bool* flag2_) { *flag1_ = *flag2_ = true; }, &flag1, &flag2);
+        pool.push_task([](bool* flag1_, bool* flag2_) {
+			*flag1_ = *flag2_ = true;
+		}, &flag1, &flag2);
         pool.wait_for_tasks();
         check(flag1 && flag2);
     }
@@ -274,20 +280,26 @@ void check_submit()
     dual_println("Checking that submit() works for a function with no arguments or return value...");
     {
         bool flag = false;
-        pool.submit([&flag] { flag = true; }).wait();
+        pool.submit([&flag] { 
+			flag = true;
+		}).wait();
         check(flag);
     }
     dual_println("Checking that submit() works for a function with one argument and no return value...");
     {
         bool flag = false;
-        pool.submit([](bool* flag_) { *flag_ = true; }, &flag).wait();
+        pool.submit([](bool* flag_) { 
+			*flag_ = true; 
+		}, &flag).wait();
         check(flag);
     }
     dual_println("Checking that submit() works for a function with two arguments and no return value...");
     {
         bool flag1 = false;
         bool flag2 = false;
-        pool.submit([](bool* flag1_, bool* flag2_) { *flag1_ = *flag2_ = true; }, &flag1, &flag2).wait();
+        pool.submit([](bool* flag1_, bool* flag2_) { 
+			*flag1_ = *flag2_ = true;
+		}, &flag1, &flag2).wait();
         check(flag1 && flag2);
     }
     dual_println("Checking that submit() works for a function with no arguments and a return value...");


### PR DESCRIPTION
test code: stick to the adagio: one statement per line. Saves hassle when debugging as setting debugger breakpoints is a line-oriented dev activity.

---

From: SHA-1: de3247306c4ae9e370e740579deb6e235ef96b9a

- reformatted some of the tests to adhere to 'one statement per line' to help us debugging the tests while we were working on the threadpool innards.

[rest submitted in other PRs]


---

**Testing**

This was tested as part of a larger work (other PRs are forthcoming shortly) after hunting down shutdown issues (application lockups, etc.) in a large application.

Tested this code via your provided test code rig; see my own fork and the referenced commits which point into there.

Tested on AMD Ryzen 3700X, 128GB RAM, latest Win10/64, latest MSVC2019 dev environment. Using in-house project files which use a (in-house) standardized set of optimizations. 

**Additional information**

**TBD**

The patches are hopefully largely self-explanatory. Where deemed useful, the original commit messages from the dev fork have been referenced and included.
