### PR TITLE
slight augmentation of the benchmark

### DIFF
--- a/BS_thread_pool_test.cpp
+++ b/BS_thread_pool_test.cpp
@@ -949,15 +949,18 @@ void check_performance()
     const BS::concurrency_t thread_count = pool.get_thread_count();
     dual_println("Using ", thread_count, " threads.");
 
+#if defined(_MSC_VER)
+#pragma warning(disable: 4838) // warning C4838: conversion from 'double' to 'const BS::concurrency_t' requires a narrowing conversion
+#endif
     // Define the number of tasks to try in each run of the test (0 = single-threaded).
-    const BS::concurrency_t try_tasks[] = {0, thread_count / 4, thread_count / 2, thread_count, thread_count * 2, thread_count * 4};
+    const BS::concurrency_t try_tasks[] = {0, thread_count / 4, thread_count / 3, thread_count / 2, thread_count / 1.5, thread_count / 1.2, thread_count - 1, thread_count, thread_count + 1, thread_count * 1.2, thread_count * 1.5, thread_count * 2, thread_count * 3, thread_count * 4};
 
     // How many times to repeat each run of the test in order to collect reliable statistics.
     constexpr size_t repeat = 20;
     dual_println("Each test will be repeated ", repeat, " times to collect reliable statistics.");
 
     // The target execution time, in milliseconds, of the multi-threaded test with the number of blocks equal to the number of threads. The total time spent on that test will be approximately equal to repeat * target_ms.
-    constexpr std::chrono::milliseconds::rep target_ms = 50;
+    constexpr std::chrono::milliseconds::rep target_ms = 100;
 
     // Test how many vectors we need to generate, and of what size, to roughly achieve the target execution time.
     dual_println("Determining the number and size of vectors to generate in order to achieve an approximate mean execution time of ", target_ms, " ms with ", thread_count, " tasks...");


### PR DESCRIPTION
This work is related to benchmark fixes in other PR.

From: SHA-1: de3247306c4ae9e370e740579deb6e235ef96b9a

- we also increased the target time from 50 to 100ms to get slightly better granularity in the measurements.

- added more thread counts to try in the benchmark, in particular: what happens if we run on all cores but one? what happens if we load the cores with slightly more threads then there are cores? And what if there's slightly less? A regular machine is NEVER clean as there's always background work by the OS, etc. happening. Some times it could be handy to see what happens with the threadpool performance under reasonable 'independent load', i.e. seeking answers to: what is a better size when used in conjunction with other software on the same machine? After all, this threadpool is not expected to exist and lord it over all by its lonesome. ;-)

  See also the benchmarks below: funnily enough the benchmark can now tell us to reserve "for one core less, please" when running on a lightly loaded box -- at least that's what happened to me and what was observed, driving the change for `thread_count` from size_t/unsigned int type towards a *signed* integer value: that way, our application can spec a threadpool at 'thread_count = -1' or similar and deliver a nice performance experience while the application(s) running on that box at the same time also get to have a slice of the pie, without too much of a fight. Observed on a AMD Ryzen 3700X with 128GB and a light "normal everyday" load: the advice there is now to use 'thread_count = -1' instead of the previous default 'thread_count = 0' (i.e. "use all cores").

The benchmarks below were run with slightly different external loads and at different times of the day. I picked these to showcase what was observed, but surely there were also enough benchmark runs that landed on the other side of the fence and said "16" (i.e. 'thread_count = 0' is a-okay). One benchmark even went for 'thread_count = 64' i.e. loading each core by a factor of 4, as the most sane approach -- it isn't but with the benchmark the cost change is almost negligible once you start pushing threads into a core. I expect this to be worse in practice where applications and tasks using this threadpool are significantly larger, both in cpu cost and memory footprints. Read: I expect way more cache thrashing when applied to a real-world, sizeable app. So we'll stick with the 'thread_count = 0' and 'thread_count = -1' advice.  ;-)

---

```
======================
Performing benchmarks:
======================
Using 16 threads.
Each test will be repeated 20 times to collect reliable statistics.
Determining the number and size of vectors to generate in order to achieve an approximate mean execution time of 100 ms with 16 tasks...
tmr.ms:    0, target_ms: 100, factor: 101.000000, damped: 2.000000, delta: 101.000000, vector_size: 128
tmr.ms:    0, target_ms: 100, factor: 101.000000, damped: 2.000000, delta: 0.000000, vector_size: 256
tmr.ms:    2, target_ms: 100, factor: 33.666668, damped: 2.000000, delta: 67.333328, vector_size: 512
tmr.ms:    9, target_ms: 100, factor: 10.100000, damped: 2.000000, delta: 23.566668, vector_size: 1024
tmr.ms:   38, target_ms: 100, factor: 2.589744, damped: 2.000000, delta: 7.510257, vector_size: 2048
tmr.ms:  101, target_ms: 100, factor: 0.990196, damped: 0.990196, delta: 1.599548, vector_size: 4096
tmr.ms:  118, target_ms: 100, factor: 0.848740, damped: 0.848740, delta: 0.141457, vector_size: 4055
tmr.ms:   85, target_ms: 100, factor: 1.174419, damped: 1.174419, delta: 0.325679, vector_size: 3441
tmr.ms:  103, target_ms: 100, factor: 0.971154, damped: 0.971154, delta: 0.203265, vector_size: 4041
tmr.ms:   99, target_ms: 100, factor: 1.010000, damped: 1.010000, delta: 0.038846, vector_size: 3924
Generating 3968 vectors with 3924 elements each:
Single-threaded, mean execution time was  975.0 ms with standard deviation  6.8 ms.
With    4 tasks, mean execution time was  255.5 ms with standard deviation  5.9 ms.
With    5 tasks, mean execution time was  205.7 ms with standard deviation  4.3 ms.
With    8 tasks, mean execution time was  146.5 ms with standard deviation  3.7 ms.
With   10 tasks, mean execution time was  122.4 ms with standard deviation  1.9 ms.
With   13 tasks, mean execution time was   98.7 ms with standard deviation  1.2 ms.
With   15 tasks, mean execution time was   92.1 ms with standard deviation  4.6 ms.
With   16 tasks, mean execution time was   94.5 ms with standard deviation  9.1 ms.
With   17 tasks, mean execution time was  138.1 ms with standard deviation  2.2 ms.
With   19 tasks, mean execution time was  127.1 ms with standard deviation  1.8 ms.
With   24 tasks, mean execution time was  106.2 ms with standard deviation  1.8 ms.
With   32 tasks, mean execution time was  100.7 ms with standard deviation  7.4 ms.
With   48 tasks, mean execution time was  110.4 ms with standard deviation  3.3 ms.
With   64 tasks, mean execution time was   99.5 ms with standard deviation  2.2 ms.
Maximum speedup obtained by multithreading vs. single-threading: 10.6x, using 15 tasks.

+++++++++++++++++++++++++++++++++++++++
Thread pool performance test completed!
+++++++++++++++++++++++++++++++++++++++

======================
Performing benchmarks:
======================
Using 16 threads.
Each test will be repeated 20 times to collect reliable statistics.
Determining the number and size of vectors to generate in order to achieve an approximate mean execution time of 100 ms with 16 tasks...
tmr.ms:    0, target_ms: 100, factor: 101.000000, damped: 2.000000, delta: 101.000000, vector_size: 128
tmr.ms:    0, target_ms: 100, factor: 101.000000, damped: 2.000000, delta: 0.000000, vector_size: 256
tmr.ms:    2, target_ms: 100, factor: 33.666668, damped: 2.000000, delta: 67.333328, vector_size: 512
tmr.ms:    8, target_ms: 100, factor: 11.222222, damped: 2.000000, delta: 22.444447, vector_size: 1024
tmr.ms:   26, target_ms: 100, factor: 3.740741, damped: 2.000000, delta: 7.481482, vector_size: 2048
tmr.ms:  103, target_ms: 100, factor: 0.971154, damped: 0.971154, delta: 2.769587, vector_size: 4096
tmr.ms:  112, target_ms: 100, factor: 0.893805, damped: 0.893805, delta: 0.077349, vector_size: 3977
tmr.ms:   85, target_ms: 100, factor: 1.174419, damped: 1.174419, delta: 0.280613, vector_size: 3554
tmr.ms:  115, target_ms: 100, factor: 0.870690, damped: 0.870690, delta: 0.303729, vector_size: 4173
tmr.ms:   93, target_ms: 100, factor: 1.074468, damped: 1.074468, delta: 0.203779, vector_size: 3633
tmr.ms:  106, target_ms: 100, factor: 0.943925, damped: 0.943925, delta: 0.130543, vector_size: 3903
tmr.ms:   95, target_ms: 100, factor: 1.052083, damped: 1.052083, delta: 0.108158, vector_size: 3684
tmr.ms:   96, target_ms: 100, factor: 1.041237, damped: 1.041237, delta: 0.010846, vector_size: 3875
Generating 4032 vectors with 3875 elements each:
Single-threaded, mean execution time was  969.9 ms with standard deviation  5.0 ms.
With    4 tasks, mean execution time was  252.5 ms with standard deviation  4.4 ms.
With    5 tasks, mean execution time was  207.6 ms with standard deviation  5.2 ms.
With    8 tasks, mean execution time was  151.8 ms with standard deviation  4.2 ms.
With   10 tasks, mean execution time was  124.6 ms with standard deviation  2.0 ms.
With   13 tasks, mean execution time was   98.4 ms with standard deviation  1.1 ms.
With   15 tasks, mean execution time was   89.7 ms with standard deviation  3.8 ms.
With   16 tasks, mean execution time was   92.0 ms with standard deviation  8.0 ms.
With   17 tasks, mean execution time was  135.4 ms with standard deviation  0.8 ms.
With   19 tasks, mean execution time was  123.8 ms with standard deviation  2.3 ms.
With   24 tasks, mean execution time was  105.2 ms with standard deviation  1.9 ms.
With   32 tasks, mean execution time was   89.8 ms with standard deviation  5.8 ms.
With   48 tasks, mean execution time was   90.4 ms with standard deviation  6.0 ms.
With   64 tasks, mean execution time was   90.8 ms with standard deviation  4.8 ms.
Maximum speedup obtained by multithreading vs. single-threading: 10.8x, using 15 tasks.

+++++++++++++++++++++++++++++++++++++++
Thread pool performance test completed!
+++++++++++++++++++++++++++++++++++++++
```


---

**Testing**

This was tested as part of a larger work (other PRs are forthcoming shortly) after hunting down shutdown issues (application lockups, etc.) in a large application.

Tested this code via your provided test code rig; see my own fork and the referenced commits which point into there.

Tested on AMD Ryzen 3700X, 128GB RAM, latest Win10/64, latest MSVC2019 dev environment. Using in-house project files which use a (in-house) standardized set of optimizations. 

**Additional information**

**TBD**

The patches are hopefully largely self-explanatory. Where deemed useful, the original commit messages from the dev fork have been referenced and included.
