### PR TITLE
README: fix MarkDown render mistakes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This is the complete documentation for v3.3.0 of the library, released on 2022-0
 
 ### Motivation
 
-Multithreading is essential for modern high-performance computing. Since C++11, the C++ standard library has included built-in low-level multithreading support using constructs such as `std::thread`. However, `std::thread` creates a new thread each time it is called, which can have a significant performance overhead. Furthermore, it is possible to create more threads than the hardware can handle simultaneously, potentially resulting in a substantial slowdown.
+Multithreading is essential for modern high-performance computing. Since C\+\+11, the C\+\+ standard library has included built-in low-level multithreading support using constructs such as `std::thread`. However, `std::thread` creates a new thread each time it is called, which can have a significant performance overhead. Furthermore, it is possible to create more threads than the hardware can handle simultaneously, potentially resulting in a substantial slowdown.
 
 The library presented here contains a thread pool class, `BS::thread_pool`, which avoids these issues by creating a fixed pool of threads once and for all, and then continuously reusing the same threads to perform different tasks throughout the lifetime of the program. By default, the number of threads in the pool is equal to the maximum number of threads that the hardware can run in parallel.
 


### PR DESCRIPTION
README: fix MarkDown render mistakes in MSVC IDE (& possibly elsewhere): `C++17` was rendered as strike-through instead of literal `C++17`.
