### PR TITLE
make worker threads robust and able to catch catastrophic failures for more controlled general application shutdown and post mortem.

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -513,9 +513,9 @@ public:
         waiting = false;
     }
 
-private:
+protected:
     // ========================
-    // Private member functions
+    // Protected member functions
     // ========================
 
     /**
@@ -526,7 +526,7 @@ private:
         running = true;
         for (concurrency_t i = 0; i < thread_count; ++i)
         {
-            threads[i] = std::thread(&thread_pool::worker, this);
+            threads[i] = std::thread(&thread_pool::workerthread_main, this);
         }
     }
 
@@ -584,6 +584,16 @@ private:
                     task_done_cv.notify_one();
             }
         }
+    }
+
+    /**
+     * @brief The base wrapper for the thread worker. Can be overridden in derived classes if your application needs special preparations in your worker threads.
+     *
+     * This method is supposed to invoke the `worker()` method.
+     */
+    virtual void workerthread_main()
+    {
+        worker();
     }
 
     // ============

--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -839,6 +839,8 @@ protected:
      */
     [[nodiscard]] bool __worker_SEH(std::string &worker_failure_message)
     {
+        ASSERT_AND_CONTINUE(worker_failure_message.capacity() >= 70 + 150 + 80);
+
         alive_threads_count++;
 
         __try
@@ -856,6 +858,7 @@ protected:
                 // see also the comments in the workerthread_main() method
                 size_t slen = worker_failure_message.length();
                 size_t scap = worker_failure_message.capacity() - slen;
+                ASSERT_AND_CONTINUE(scap >= 70);
                 if (scap >= 70)
                 {
                     if (slen > 0)
@@ -864,6 +867,7 @@ protected:
                         scap--;
                     }
                     snprintf(&worker_failure_message[slen], scap, "%s: thread::worker unwinding; termination is %s.", AbnormalTermination() ? "ERROR" : "INFO", AbnormalTermination() ? "ABNORMAL" : "normal");
+                    ASSERT(strlen(&worker_failure_message[slen]) < 70);
                 }
             }
         }
@@ -882,6 +886,7 @@ protected:
             // see also the comments in the workerthread_main() method
             size_t slen = worker_failure_message.length();
             size_t scap = worker_failure_message.capacity() - slen;
+            ASSERT_AND_CONTINUE(scap >= 150);
             if (scap >= 150)
             {
                 if (slen > 0)
@@ -952,6 +957,7 @@ case x:																																												\
                     break;
                 }
                 worker_failure_message[scap - 1] = 0;		// snprintf() doesn't guarantee a NUL at the end. **We do.**
+                ASSERT(strlen(&worker_failure_message[slen]) < 150);
 
 #if 0
                 if (p)

--- a/BS_thread_pool_test.cpp
+++ b/BS_thread_pool_test.cpp
@@ -214,6 +214,8 @@ void check_constructor()
     check(std::thread::hardware_concurrency(), pool.get_thread_count());
     dual_println("Checking that the manually counted number of unique thread IDs is equal to the reported number of threads...");
     check(pool.get_thread_count(), count_unique_threads());
+	dual_println("Checking that the tracked number of alive threads is equal to the setup thread count...");
+	check(pool.get_thread_count(), pool.get_alive_threads_count());
 }
 
 /**


### PR DESCRIPTION
> **Note**
>
> This work builds upon https://github.com/bshoshany/thread-pool/pull/76, hence it is merged as part of this commit chain to the individual commit deltas small, comprehensible and mergeable.

Adding *virtual member function* `workerthread_main()` which is used to wrap every worker thread's `worker()` method: this prepares us for two features to be submitted:

1. per thread catastrophic failure handling, where worker threads gain the ability to detect catastrophic failures, e.g. uncaught exceptions and hardware faults, and help to terminate the application in a controlled fashion.

2. allowing applications to use a derived class which is used to provide advanced per-worker-thread setup and shutdown procedures which are application-specific. (Hence the *virtual* method.)

---

Merge branch 'patch-7' (i.e. https://github.com/bshoshany/thread-pool/pull/76 ) -- patch-7 is a mandatory prerequisite for this work.

---


added the `get_alive_threads_count()` monitoring feature, which tracks the worker threads 'life': this is in preparation of the catastrophic failure handling feature.

---


## Revision: 598f66ff8f5e183c12f378daca0593f71d43c7ff

Phase 1 of the per-workerthread catastrophic failure handling code: this contains the platform-generic part, which is able to catch unhandled exceptions and report those to any custom `workerthread_main()` reporter.

> This is the inverse of commit ad63b02290e4debeeae388bbce925426cb023071 as it was easier to remove the features one-by-one when I was extracting this bit of work from the dev commits, then revert those onto here.

Originally From SHA-1: 12253b6610ed2f237660abeb91446beab27f63d1

**augmentations**:

- thread workers now wait for a signal to wake up when in 'pause mode', as they always already were in normal run mode.

[...]

  Note that, at least under Windows 10, threads MAY be nuked silently under fatal/crash/exception conditions, in which case the thread disappears even before it was able to do anything simple, like updating the `alive_threads_count` count, because the thread worker code simply will cease to run and exist. Fortunately, thread::is_joinable() detects this fact -- which was a very important reason to have `wait_for_tasks()` be a wait_for_tasks()-timed poll loop, as we CANNOT guarantee on all OSes that worker threads will be able to wake up and act once a severe-enough fault condition has occurred in the application/task code. From our own observations, it already seems sufficient to directly, bluntly, call the standard `exit(N)` RTL API to have this happen to you: no exception of any kind will be reported then, yet all threads will be joinable as they will have *vanished* already.

WARNING: hence, `get_alive_threads_count()` will be unsafely optimistic and depending on that number at such disparate times will surely cause your application to lock up on exit on semi-random occasions. This is completely independent of the `running` state, as this is driven by external factors.

- catch unexpected C++ and SEH/hardware exceptions occurring in your tasks/worker-threads in the outer layers of the worker thread: as this is a catastrophic, fatal, condition anyway (your application state is largely unpredictable by then already), the thread will terminate, but we now have a fighting chance of catching and reporting such errors at least. As C++ and SEH exception handling cannot co-exist in a single function, we have the following call chain, where each wraps the next one: workerthread_main() --> __worker_SEH() --> __worker() --> worker(), where worker() is the core threadpool thread code, waiting for and executing tasks once they arrive.

  When you need special handling of this (fatal) scenario in your application, you can create a derived class and override the workerthread_main() with your own. Observe the code comments when you do to ensure continued proper operation of the threadpool. (`__worker_SEH()` returns a boolean indicating whether its termination was due to normal or abnormal (i.e. catastrophic failure) termination, while you may pass a string to them, which will now have been filled with the relevant and available error information. The given implementation prints this info the STDERR -- but you can replace that behaviour in your override.

----



## Revision: 57d067a405c646f8f1e43f1c949b2c57bb7b7b66

Add support for *negative* `thread_count`: '*this few less than number of CPU cores*' setup feature.

From the original: SHA-1: 12253b6610ed2f237660abeb91446beab27f63d1

- now accepts NEGATIVE `thread_counts` during pool creation (or `reset()`) to create a pool that's occupying *all CPU cores MINUS thread_count*. This is useful when you want the pool to occupy ALMOST all cores, but leave one or more for other, unrelated, jobs.

**... Which is a feature due to the results from SHA-1: de3247306c4ae9e370e740579deb6e235ef96b9a: see https://github.com/bshoshany/thread-pool/pull/74 and https://github.com/bshoshany/thread-pool/pull/75 for that bit of the work.**

> This is produced as a revert of commit 3109b5c146f1ce50855b92ba57a8324a160588b3 as it was easier to remove features from a existing and tested-ok rig than build up from scratch on a new tree.





## Revision: 635472fff414f6b3d82fa98aaeb7147ddc70ba02

`wait_for_tasks()`: remove the need to use YIELD by slowly growing the poll period until it hits a preconfigured ceiling (1 second); this code is generally only relevant in abnormal application terminations, but helps to keep it civil at those times.

> This reverts commit f7551e41cd5c85d724dfb47b3d94ec03afc76798 as it was easier to remove features from an existing and known-good code rig than build up from scratch on a different tree, so produced a remove patch there and then reverted it onto here. *Ach.*🤷‍♀️



## Revision: 34b6aa53e3453ea39209e6510b945f16b9e10dd7

add the original `ASSERT`ion checks, which document and test the implicit assumptions at critical places in the code. We *explicitly decide* NOT to use STD RTL `<assert.h>` et al as those are very inflexible, not allowing one, for example, to continue debugging an application when an assertion fails. These are engineered to be replaced by application/test specific macros; their default implementation (on Windows at least) will wake up your attached debugger -- if you were running any.

> Works nicely for me at least with a MSVC2019 dev rig. 😄 

> Again, this is another inverse of a commit: 72424f2c65e1b2cbe36c781b5dc35971b66d5417. It was easier to remove features from a known-good rig and then revert those commits onto here.🤷‍♀️




## Revision: 97b10acc32ac21b50089a31e7a1c5b919f3add59

Phase 2 of the per-threadworker catastrophic failure handling and controlled termination: adding [MSWindows-specific SEH handling](https://docs.microsoft.com/en-us/cpp/cpp/structured-exception-handling-c-cpp?view=msvc-170), which allows an application to catch and process hardware failures of various kinds, e.g. bus errors and DIV/0. This allows advanced applications to cope with internal failures and shut down in a controlled fashion - even while the state of a large chunk of the application may arguably already be 'in limbo'.

"adding the MSVC-specific extra SEH catastrophic failure handling code. Based on the already-present generic skeleton rig, so the change is minimal. This basically fleshes out the `__worker_SEH()` wrapper method."

> This reverts commit 4c0774a860a1534aae19424893dfe619b21fcac8. It was easier to remove features from a known-good rig than to build up from scratch on a different tree, so we created the removal commit there, then reverted that one onto here.




## Revision: bb550265245caae76e137531baf1b8527c85265b

Continuation of SHA-1: 59c4193a44d9bdb858a1d66ca90ea9c62bf1331a, adding the omitted original `ASSERT`ion checks, which are applicable now that the SEH handling code in `__worker_SEH()` has finally been introduced.


---



🥴😱 whoopsie! forgot to add the `get_alive_threads_count()` test which was added to check the new added API. Done now. ✅





---

**Testing**

This was tested as part of a larger work (see the previous PRs) after hunting down shutdown issues (application lockups, etc.) in a large application.

Tested this code via your provided test code rig; see my own fork and the referenced commits which point into there.

Tested on AMD Ryzen 3700X, 128GB RAM, latest Win10/64, latest MSVC2019 dev environment. Using in-house project files which use a (in-house) standardized set of optimizations. 

**Additional information**

**TBD**

The patches are hopefully largely self-explanatory. Where deemed useful, the original commit messages from the dev fork have been referenced and included.
