### PR TITLE
Fixed possible memory order bug

### DIFF
--- a/BS_thread_pool_light.hpp
+++ b/BS_thread_pool_light.hpp
@@ -140,6 +140,8 @@ public:
             const std::scoped_lock tasks_lock(tasks_mutex);
             tasks.push(task_function);
         }
+
+        const std::lock_guard tasks_lock(tasks_mutex);
         ++tasks_total;
         task_available_cv.notify_one();
     }
@@ -221,8 +223,11 @@ private:
      */
     void destroy_threads()
     {
-        running = false;
-        task_available_cv.notify_all();
+        {
+            const std::lock_guard tasks_locker( tasks_mutex );
+            running = false;
+            task_available_cv.notify_all();
+        }
         for (concurrency_t i = 0; i < thread_count; ++i)
         {
             threads[i].join();


### PR DESCRIPTION
**Describe the changes**

I believe, there was a memory order bug, concerning usage of atomic flags before condition_variable.notify.
According to https://en.cppreference.com/w/cpp/thread/condition_variable
> Even if the shared variable is atomic, it must be modified under the mutex in order to correctly publish the modification to the waiting thread.

So I fenced both flags and notify statement with mutex.

**Testing**

Have you tested the new code using the provided automated test program and/or performed any other tests to ensure that it works correctly? If so, please provide information about the test system(s):

Yes, I did.

* CPU model, architecture, # of cores and threads: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz   2.71 GHz, 2 cores, 4 threads
* Operating system: Windows 10 Pro, x64
* Name and version of C++ compiler: Visual Studio 19 compiler
* Full command used for compiling, including all compiler flags: I don't think it matters.

**Additional information**

When I used Your project as a template for my personal project, I had a bug where threads would be notified before end flag set to true causing deadlock. It was captured using high-end system and I could not replicate it on my personal computer.
