### PR TITLE
Add get_thread_index method

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -513,6 +513,20 @@ public:
         waiting = false;
     }
 
+    /**
+     * @brief Inside a task, retrieve the index of the current thread within the pool. If called from a thread outside the pool, returns -1.
+     */
+    [[nodiscard]] concurrency_t get_thread_index() const
+    {
+        const std::thread::id this_thread_id = std::this_thread::get_id();
+        for (concurrency_t i = 0; i < thread_count; ++i)
+        {
+            if (threads[i].get_id() == this_thread_id)
+                return i;
+        }
+        return static_cast<concurrency_t>(-1);
+    }
+
 private:
     // ========================
     // Private member functions


### PR DESCRIPTION
**Describe the changes**

Adds a method to `thread_pool` which, when called from one of its worker threads, returns the 0-based index of the thread within the pool. If called from a thread outside the pool, returns -1.

The motivation for this is that in our project, we have some data structures which are allocated per-worker-thread and stored in an array. We use this for things like accumulating statistics per-thread which are combined together later. We had been using TBB and it exposes this thread index as `tbb::this_task_arena::current_thread_index()`. When porting to bshoshany-thread-pool, I found there wasn't an equivalent method.

**Testing**

Tested in the context of our project (a high performance CPU raytracer) on both Windows and Mac machines.

* CPU model, architecture, # of cores and threads: 
    * AMD Ryzen 9 5950X, 16 cores, 32 threads
    * Intel Core i9, 8 cores, 16 threads
    * Apple M1, 8 cores, 8 threads
* Operating system:
    * Windows 10 21H2
    * macOS 11.8.6
* Name and version of C++ compiler:
    * MSVC 16.11
    * Apple Clang 13.0 for x86_64
    * Apple Clang 13.0 for arm64
