### PR TITLE
Remove unnecessary copies of submitted functions to the threadpool.

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -427,7 +427,7 @@ public:
         std::function<void()> task_function = std::bind(std::forward<F>(task), std::forward<A>(args)...);
         {
             const std::scoped_lock tasks_lock(tasks_mutex);
-            tasks.push(task_function);
+            tasks.push(std::move(task_function));
         }
         ++tasks_total;
         task_available_cv.notify_one();
@@ -466,7 +466,7 @@ public:
         std::function<R()> task_function = std::bind(std::forward<F>(task), std::forward<A>(args)...);
         std::shared_ptr<std::promise<R>> task_promise = std::make_shared<std::promise<R>>();
         push_task(
-            [task_function, task_promise]
+            [task_function {std::move(task_function)}, task_promise]
             {
                 try
                 {

--- a/BS_thread_pool_light.hpp
+++ b/BS_thread_pool_light.hpp
@@ -138,7 +138,7 @@ public:
         std::function<void()> task_function = std::bind(std::forward<F>(task), std::forward<A>(args)...);
         {
             const std::scoped_lock tasks_lock(tasks_mutex);
-            tasks.push(task_function);
+            tasks.push(std::move(task_function));
         }
         ++tasks_total;
         task_available_cv.notify_one();
@@ -160,7 +160,7 @@ public:
         std::function<R()> task_function = std::bind(std::forward<F>(task), std::forward<A>(args)...);
         std::shared_ptr<std::promise<R>> task_promise = std::make_shared<std::promise<R>>();
         push_task(
-            [task_function, task_promise]
+            [task_function {std::move(task_function)}, task_promise]
             {
                 try
                 {

--- a/BS_thread_pool_light_test.cpp
+++ b/BS_thread_pool_light_test.cpp
@@ -215,6 +215,24 @@ void check_push_task()
     }
 }
 
+class copy_counter {
+public:
+    copy_counter() = default;
+
+    copy_counter(const copy_counter& other): counter{other.counter + 1}
+    {
+        std::cout << "Counter is now" << counter << '\n';
+    }
+    copy_counter(copy_counter&&) = default;
+
+    unsigned value() const noexcept
+    {
+        return counter;
+    }
+private:
+       unsigned counter = 0;
+};
+
 /**
  * @brief Check that submit() works.
  */
@@ -274,6 +292,15 @@ void check_submit()
             },
             &flag1, &flag2);
         check(flag_future.get() == 42 && flag1 && flag2);
+    }
+    println("Checking that submit() doesn't create extra copies of the function object...");
+    {
+        std::future<unsigned> copy_future = pool.submit(
+            [counter {copy_counter()}]()
+            {
+                return counter.value();
+            });
+        check(0u, copy_future.get());
     }
 }
 

--- a/BS_thread_pool_test.cpp
+++ b/BS_thread_pool_test.cpp
@@ -266,6 +266,24 @@ void check_push_task()
     }
 }
 
+class copy_counter {
+public:
+    copy_counter() = default;
+
+    copy_counter(const copy_counter& other): counter{other.counter + 1}
+    {
+        std::cout << "Counter is now" << counter << '\n';
+    }
+    copy_counter(copy_counter&&) = default;
+
+    unsigned value() const noexcept
+    {
+        return counter;
+    }
+private:
+       unsigned counter = 0;
+};
+
 /**
  * @brief Check that submit() works.
  */
@@ -325,6 +343,15 @@ void check_submit()
             },
             &flag1, &flag2);
         check(flag_future.get() == 42 && flag1 && flag2);
+    }
+    dual_println("Checking that submit() doesn't create extra copies of the function object...");
+    {
+        std::future<unsigned> copy_future = pool.submit(
+            [counter {copy_counter()}]()
+            {
+                return counter.value();
+            });
+        check(0u, copy_future.get());
     }
 }
 


### PR DESCRIPTION
**Pull request policy (please read)**

> Contributions are always welcome. However, I release my projects in cumulative updates after editing and testing them locally on my system, so my policy is not to accept any pull requests. If you open a pull request, and I decide to incorporate your suggestion into the project, I will first modify your code to comply with the project's coding conventions (formatting, syntax, naming, comments, programming practices, etc.), and perform some tests to ensure that the change doesn't break anything. I will then merge it into the next release of the project, possibly together with some other changes. The new release will also include a note in `CHANGELOG.md` with a link to your pull request, and modifications to the documentation in `README.md` as needed.

**Describe the changes**

Currently, the threadpool performs two unnecessary copies: one inside submit(), and another inside push_task.

This PR addresses these unnecessary copies by adding std::move to the two std::functions created in these methods when they're used.

I added a test for submit() that covers these unnecessary copies. Please note that the submitted closures must remain copyable because they're put into std::function.

**Testing**

Have you tested the new code using the provided automated test program and/or performed any other tests to ensure that it works correctly? If so, please provide information about the test system(s):

I ran both versions of tests, and wrote a new test that ensures the copies are actually avoided.

* CPU model, architecture, # of cores and threads:
* Operating system: Windows 10 Enterprise, version 10.0.19044
* Name and version of C++ compiler: Visual Studio 2019, version 16.11.19
* Full command used for compiling, including all compiler flags: `cl BS_thread_pool_test.cpp /std:c++17 /permissive- /O2 /W4 /EHsc /Fe:BS_thread_pool_test.exe`, `cl BS_thread_pool_light_test.cpp /std:c++17 /permissive- /O2 /W4 /EHsc /Fe:BS_thread_pool_light_test.exe`

**Additional information**

Example code that will benefit from this change:
```

int main() {
    BS::thread_pool pool(12);
    pool.submit(
        [big_data {std::vector<int>(100'000)}] {
	    // do stuff
	    return big_data.size();
    }).get();
    return 0;
}
```
