### PR TITLE
Add support for per-thread initialization function

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -248,10 +248,11 @@ public:
      * @brief Construct a new thread pool.
      *
      * @param thread_count_ The number of threads to use. The default value is the total number of hardware threads available, as reported by the implementation. This is usually determined by the number of cores in the CPU. If a core is hyperthreaded, it will count as two threads.
+     * @param thread_init_function_ A function to run in every thread once after creation and before any tasks, accepting thread id in range [0, thread count) as argument. Default is to do nothing. Constructor will block until all threads have finished executing it.
      */
-    thread_pool(const concurrency_t thread_count_ = 0) : thread_count(determine_thread_count(thread_count_)), threads(std::make_unique<std::thread[]>(determine_thread_count(thread_count_)))
+    thread_pool(const concurrency_t thread_count_ = 0, const std::function<void(concurrency_t)>& thread_init_function_ = [](concurrency_t) {}) : thread_count(determine_thread_count(thread_count_)), threads(std::make_unique<std::thread[]>(determine_thread_count(thread_count_)))
     {
-        create_threads();
+        create_threads(thread_init_function_);
     }
 
     /**
@@ -437,8 +438,9 @@ public:
      * @brief Reset the number of threads in the pool. Waits for all currently running tasks to be completed, then destroys all threads in the pool and creates a new thread pool with the new number of threads. Any tasks that were waiting in the queue before the pool was reset will then be executed by the new threads. If the pool was paused before resetting it, the new pool will be paused as well.
      *
      * @param thread_count_ The number of threads to use. The default value is the total number of hardware threads available, as reported by the implementation. This is usually determined by the number of cores in the CPU. If a core is hyperthreaded, it will count as two threads.
+     * @param thread_init_function_ A function to run in every thread once after creation and before any tasks, accepting thread id in range [0, thread count) as argument. Default is to do nothing. Call to this function will block until all threads have finished executing it.
      */
-    void reset(const concurrency_t thread_count_ = 0)
+    void reset(const concurrency_t thread_count_ = 0, const std::function<void(concurrency_t)>& thread_init_function_ = [](concurrency_t) {})
     {
         const bool was_paused = paused;
         paused = true;
@@ -447,7 +449,7 @@ public:
         thread_count = determine_thread_count(thread_count_);
         threads = std::make_unique<std::thread[]>(thread_count);
         paused = was_paused;
-        create_threads();
+        create_threads(thread_init_function_);
     }
 
     /**
@@ -520,14 +522,31 @@ private:
 
     /**
      * @brief Create the threads in the pool and assign a worker to each thread.
+     *
+     * @param thread_init_function A function to run in every thread once after creation and before any tasks, accepting thread id in range [0, thread count) as argument. It will be completed in every thread before returning.
      */
-    void create_threads()
+    void create_threads(const std::function<void(concurrency_t)>& thread_init_function)
     {
+        concurrency_t initialized_thread_count = 0;
+        std::condition_variable thread_initialization_done_cv = {};
+        std::mutex initialized_thread_count_mutex = {};
         running = true;
         for (concurrency_t i = 0; i < thread_count; ++i)
         {
-            threads[i] = std::thread(&thread_pool::worker, this);
+            threads[i] = std::thread(&thread_pool::worker, this,
+                [&initialized_thread_count, &thread_initialization_done_cv, &initialized_thread_count_mutex, thread_init_function, i]
+                {
+                    thread_init_function(i);
+                    {
+                        std::unique_lock<std::mutex> initialized_thread_count_lock(initialized_thread_count_mutex);
+                        ++initialized_thread_count;
+                    }
+                    thread_initialization_done_cv.notify_one();
+                }
+            );
         }
+        std::unique_lock<std::mutex> initialized_thread_count_lock(initialized_thread_count_mutex);
+        thread_initialization_done_cv.wait(initialized_thread_count_lock, [this, &initialized_thread_count] { return (initialized_thread_count == thread_count); });
     }
 
     /**
@@ -565,8 +584,10 @@ private:
     /**
      * @brief A worker function to be assigned to each thread in the pool. Waits until it is notified by push_task() that a task is available, and then retrieves the task from the queue and executes it. Once the task finishes, the worker notifies wait_for_tasks() in case it is waiting.
      */
-    void worker()
+    void worker(std::function<void()> thread_init_function)
     {
+        thread_init_function();
+        thread_init_function = {};
         while (running)
         {
             std::function<void()> task;


### PR DESCRIPTION
**Pull request policy (please read)**

> Contributions are always welcome. However, I release my projects in cumulative updates after editing and testing them locally on my system, so my policy is not to accept any pull requests. If you open a pull request, and I decide to incorporate your suggestion into the project, I will first modify your code to comply with the project's coding conventions (formatting, syntax, naming, comments, programming practices, etc.), and perform some tests to ensure that the change doesn't break anything. I will then merge it into the next release of the project, possibly together with some other changes. The new release will also include a note in `CHANGELOG.md` with a link to your pull request, and modifications to the documentation in `README.md` as needed.

**Describe the changes**

This adds support for running user-defined function once per thread on said thread's initialization, allowing user to assign custom resources to threads and closing #104. Actually storing and passing resources around is left to user, which can be accomplished fairly easily with `thread_local` variables. Function is given thread's id in thread pool as an argument, which is useful when resources are already allocated by the caller. All threads complete initialization before control is returned to caller in order to allow capturing references to caller's local variables.

**Testing**

Have you tested the new code using the provided automated test program and/or performed any other tests to ensure that it works correctly? If so, please provide information about the test system(s):

* CPU model, architecture, # of cores and threads: Intel(R) Core(TM) i3-10100 CPU @ 3.60GHz, 4 cores, 8 threads
* Operating system: Ubuntu Linux 22.10
* Name and version of C++ compiler: g++ (Ubuntu 12.2.0-3ubuntu1) 12.2.0 and Ubuntu clang version 15.0.6
* Full command used for compiling, including all compiler flags: `g++ -std=c++17 -o BS_thread_pool_test -Wall -O3 BS_thread_pool_test.cpp`, replace `g++` with `clang++` for clang

**Additional information**

I've also fixed a minor mistake in full version's tests where a few tests would fail on single-core machine due to half-concurrency being equal to zero.

Would you be interested to see a very simple build file for meson system submitted as a separate PR? It would simplify building/running tests by a fair bit, as well as make inclusion into https://github.com/mesonbuild/wrapdb seamless.

P.S.: why are .cpp files using CRLF line endings?