### PR TITLE
Fix pool shutdown deadlock

### DIFF
--- a/BS_thread_pool.hpp
+++ b/BS_thread_pool.hpp
@@ -536,7 +536,10 @@ private:
     void destroy_threads()
     {
         running = false;
-        task_available_cv.notify_all();
+        {
+            std::scoped_lock<std::mutex> tasks_lock(tasks_mutex);
+            task_available_cv.notify_all();
+        }
         for (concurrency_t i = 0; i < thread_count; ++i)
         {
             threads[i].join();

--- a/BS_thread_pool_light.hpp
+++ b/BS_thread_pool_light.hpp
@@ -222,7 +222,10 @@ private:
     void destroy_threads()
     {
         running = false;
-        task_available_cv.notify_all();
+        {
+            std::scoped_lock<std::mutex> tasks_lock(tasks_mutex);
+            task_available_cv.notify_all();
+        }
         for (concurrency_t i = 0; i < thread_count; ++i)
         {
             threads[i].join();


### PR DESCRIPTION
Fix deadlock.

The root cause is missed notifications. Condition variable `wait`/`notify` is *instantaneous*, so if a notification is sent while nobody is listening then it will be missed.

The fix is to send the notification while the `tasks_mutex` is acquired. This, combined with the predicate version of `wait` already in use, ensures that there is no way to miss the notification.

Ran against all three reported deadlock bugs and none demonstrate the issue anymore.

Fixes https://github.com/bshoshany/thread-pool/issues/107
Fixes https://github.com/bshoshany/thread-pool/issues/100
Fixes https://github.com/bshoshany/thread-pool/issues/93