### PR TITLE
Add task destroying to task processing.

### DIFF
--- a/include/BS_thread_pool.hpp
+++ b/include/BS_thread_pool.hpp
@@ -621,7 +621,6 @@ private:
      */
     void worker()
     {
-        std::function<void()> task;
         while (true)
         {
             std::unique_lock tasks_lock(tasks_mutex);
@@ -630,11 +629,12 @@ private:
                 break;
             if (paused)
                 continue;
-            task = std::move(tasks.front());
+            auto task = std::move(tasks.front());
             tasks.pop();
             ++tasks_running;
             tasks_lock.unlock();
             task();
+            task = {};
             tasks_lock.lock();
             --tasks_running;
             if (waiting && !tasks_running && (paused || tasks.empty()))

--- a/include/BS_thread_pool_light.hpp
+++ b/include/BS_thread_pool_light.hpp
@@ -255,18 +255,18 @@ private:
      */
     void worker()
     {
-        std::function<void()> task;
         while (true)
         {
             std::unique_lock tasks_lock(tasks_mutex);
             task_available_cv.wait(tasks_lock, [this] { return !tasks.empty() || !workers_running; });
             if (!workers_running)
                 break;
-            task = std::move(tasks.front());
+            auto task = std::move(tasks.front());
             tasks.pop();
             ++tasks_running;
             tasks_lock.unlock();
             task();
+            task = {};
             tasks_lock.lock();
             --tasks_running;
             if (waiting && !tasks_running && tasks.empty())


### PR DESCRIPTION
Fixes a single issue when the task queued to the pool contains a capture of shared ref. In the original code the processed task was held indefinitely, until the worker thread exited or processed another task, which was the only way to release the shared ref. (Would probably be the same for a functor.)

**Style**

>Have you formatted your code using the `.clang-format` file attached to this project? **Yes.**

**Testing**

>Have you tested the new code using the provided automated test program `BS_thread_pool_test.cpp` (preferably with the provided multi-compiler test script `BS_thread_pool_test.ps1`) and/or performed any other tests to ensure that the new code works correctly? **Used `BS_thread_pool_test.ps1` with `clang++` and `msvc`.**

If so, please provide information about the test system(s):

* CPU model, architecture, # of cores and threads: **i9-9900K (8 cores/16 threads)**
* Operating system: **Windows 10 Pro**
* Name and version of C++ compiler:
```
clang version 18.0.0 (https://github.com/llvm/llvm-project.git d65feccb126226e6f7805a01d759ca1c9ce28237)
Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33130 for x64
```
* Full command used for compiling, including all compiler flags: **The one in the script.**