### PR TITLE
push_loop balances iterations more fairly #130

### DIFF
--- a/include/BS_thread_pool.hpp
+++ b/include/BS_thread_pool.hpp
@@ -156,6 +156,7 @@ public:
             block_size = 1;
             num_blocks = (total_size > 1) ? total_size : 1;
         }
+        blocks_with_extra_task = total_size % num_blocks;
     }
 
     /**
@@ -166,7 +167,19 @@ public:
      */
     [[nodiscard]] T start(const size_t i) const
     {
-        return static_cast<T>(i * block_size) + first_index;
+        T ans = first_index;
+        if (i >= blocks_with_extra_task)
+        {
+            ans += static_cast<T>(
+                    blocks_with_extra_task*(block_size+1) +
+                    (i-blocks_with_extra_task)*block_size
+            );
+        }
+        else
+        {
+            ans += static_cast<T>(i * (block_size+1));
+        }
+        return ans;
     }
 
     /**
@@ -177,7 +190,9 @@ public:
      */
     [[nodiscard]] T end(const size_t i) const
     {
-        return (i == num_blocks - 1) ? index_after_last : (static_cast<T>((i + 1) * block_size) + first_index);
+        return start(i) + static_cast<T>(
+                block_size + (i<blocks_with_extra_task)
+        );
     }
 
     /**
@@ -225,6 +240,11 @@ private:
      * @brief The total number of indices in the range.
      */
     size_t total_size = 0;
+
+    /**
+     * @brief The number of blocks with one extra task
+     */
+    size_t blocks_with_extra_task = 0;
 };
 
 //                                        End class blocks                                       //

--- a/include/BS_thread_pool_light.hpp
+++ b/include/BS_thread_pool_light.hpp
@@ -101,10 +101,17 @@ public:
             block_size = 1;
             num_blocks = (total_size > 1) ? total_size : 1;
         }
+        size_t blocks_with_extra_task = total_size % num_blocks;
         if (total_size > 0)
         {
+            T start = first_index;
             for (size_t i = 0; i < num_blocks; ++i)
-                push_task(std::forward<F>(loop), static_cast<T>(i * block_size) + first_index, (i == num_blocks - 1) ? index_after_last : (static_cast<T>((i + 1) * block_size) + first_index));
+            {
+                size_t this_block_size = block_size + (i < blocks_with_extra_task);
+                T end = start + static_cast<T>(this_block_size);
+                push_task(std::forward<F>(loop), start, end);
+                start = end;
+            }
         }
     }
 


### PR DESCRIPTION
**Changes**

For push_loop, iterations are split more equally among blocks. Instead of assigning all the extra iterations to the last block, the first total_size%num_blocks thread complete one additional iteration. Therefore, every thread completes between block_size and block_size+1 iteration, instead of having a single thread complete up to block_size + total_size % num_block iterations.

**Style**

I'm not familiar with formatting tools, so I have not used Clang formatter. However, the changes are minimal and, if need be, it should be easy to adapt them to the rest of the code.

**Testing**

The code has been tested using the supplied test battery.

Test system(s):

* Intel Core i7-8700k @ 3.7 GHz:
* Ubuntu 18.04
* gcc 7.5 and clang 6
* Cmd options: the provided ones with BS_thread_pool_test.ps1

**Additional information**

N/A
