### PR TITLE
Fix warnings caught by gcc's -Wuseless-cast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ For maximum performance, it is recommended to compile with all available compile
 
 As an example, to compile the test program `BS_thread_pool_test.cpp` with warnings and optimizations, it is recommended to use the following commands:
 
-* On Linux with GCC: `g++ BS_thread_pool_test.cpp -std=c++17 -O3 -Wall -Wextra -Wconversion -Wsign-conversion -Wpedantic -Weffc++ -Wshadow -pthread -o BS_thread_pool_test`
-* On Linux with Clang: replace `g++` with `clang++`.
-* On Windows with GCC or Clang: replace `-o BS_thread_pool_test` with `-o BS_thread_pool_test.exe` and remove `-pthread`.
+* On Linux with GCC: `g++ BS_thread_pool_test.cpp -std=c++17 -O3 -Wall -Wextra -Wconversion -Wsign-conversion -Wpedantic -Weffc++ -Wshadow -Wuseless-cast -pthread -o BS_thread_pool_test`
+* On Linux with Clang: replace `g++` with `clang++` and remove `-Wuseless-cast`.
+* On Windows with GCC or Clang: replace `-o BS_thread_pool_test` with `-o BS_thread_pool_test.exe` and remove `-pthread` and `-Wuseless-cast`.
 * On Windows with MSVC: `cl BS_thread_pool_test.cpp /std:c++17 /permissive- /O2 /W4 /EHsc /Fo:BS_thread_pool_test.obj /Fe:BS_thread_pool_test.exe`
 
 ## Getting started

--- a/include/BS_thread_pool.hpp
+++ b/include/BS_thread_pool.hpp
@@ -952,8 +952,8 @@ private:
                 const size_t total_size = static_cast<size_t>(index_after_last - first_index);
                 if (num_blocks > total_size)
                     num_blocks = total_size;
-                block_size = static_cast<size_t>(total_size / num_blocks);
-                remainder = static_cast<size_t>(total_size % num_blocks);
+                block_size = total_size / num_blocks;
+                remainder = total_size % num_blocks;
                 if (block_size == 0)
                 {
                     block_size = 1;


### PR DESCRIPTION
**Pull request policy (please read)**

> Contributions are always welcome. However, I release my projects in cumulative updates after editing and testing them locally on my system, so my policy is not to accept any pull requests. If you open a pull request, and I decide to incorporate your suggestion into the project, I will first modify your code to comply with the project's coding conventions (formatting, syntax, naming, comments, programming practices, etc.), and perform some tests to ensure that the change doesn't break anything. I will then merge it into the next release of the project, possibly together with some other changes. The new release will also include a note in `CHANGELOG.md` with a link to your pull request, and modifications to the documentation in `README.md` as needed.

**Describe the changes**

> What does your pull request fix or add to the library?

This pull request removes some useless static casts from type `size_t` to type `size_t`, and adds the warning specification to the `README.md`.

**Style**

> Have you formatted your code using the `.clang-format` file attached to this project?

Yes.

**Linting**

> Have you linted your code using the `.clang-tidy` file attached to this project?

Yes

**Testing**

> Have you tested the new code using the provided automated test program `BS_thread_pool_test.cpp` (preferably with the provided multi-compiler test script `BS_thread_pool_test.ps1`) and/or performed any other tests to ensure that the new code works correctly?
> If so, please provide information about the test system(s):
> * CPU model, architecture, # of cores and threads:
> * Operating system:
> * Name and version of C++ compiler:
> * Full command used for compiling, including all compiler flags:

* CPU: 12th Gen Intel(R) Core(TM) i5-1240P
* architecture: x86_64
* num cores: 12
* num threads: 24
* OS: Ubuntu 23.10
* compiler: gcc-13.2.0
* cmd: `g++ BS_thread_pool_test.cpp -I../include -std=c++17 -O3 -Wall -Wextra -Wconversion -Wsign-conversion -Wpedantic -Weffc++ -Wshadow -Wuseless-cast -pthread -o BS_thread_pool_test`

**Additional information**

> Include any additional information here.

None