### PR TITLE
Support C++20 module with optional standard library module

### DIFF
--- a/include/BS_thread_pool.hpp
+++ b/include/BS_thread_pool.hpp
@@ -15,6 +15,7 @@
     #undef BS_THREAD_POOL_ENABLE_WAIT_DEADLOCK_CHECK
 #endif
 
+#ifndef BS_THREAD_POOL_USE_STD_MODULE
 #include <chrono>             // std::chrono
 #include <condition_variable> // std::condition_variable
 #include <cstddef>            // std::size_t
@@ -37,6 +38,7 @@
 #include <type_traits>        // std::conditional_t, std::decay_t, std::invoke_result_t, std::is_void_v, std::remove_const_t (if priority enabled)
 #include <utility>            // std::forward, std::move
 #include <vector>             // std::vector
+#endif
 
 /**
  * @brief A namespace used by Barak Shoshany's projects.

--- a/include/BS_thread_pool_utils.hpp
+++ b/include/BS_thread_pool_utils.hpp
@@ -10,6 +10,7 @@
  * @brief BS::thread_pool: a fast, lightweight, and easy-to-use C++17 thread pool library. This header file contains independent utility classes that are part of the library, but are not needed to use the thread pool itself.
  */
 
+#ifndef BS_THREAD_POOL_USE_STD_MODULE
 #include <chrono>           // std::chrono
 #include <future>           // std::promise, std::shared_future
 #include <initializer_list> // std::initializer_list
@@ -18,6 +19,7 @@
 #include <mutex>            // std::mutex, std::scoped_lock
 #include <ostream>          // std::endl, std::flush, std::ostream
 #include <utility>          // std::forward
+#endif
 
 /**
  * @brief A namespace used by Barak Shoshany's projects.

--- a/module/BS_thread_pool.cppm
+++ b/module/BS_thread_pool.cppm
@@ -1,0 +1,35 @@
+module;
+
+#ifndef BS_THREAD_POOL_USE_STD_MODULE
+#include <BS_thread_pool.hpp>
+#include <BS_thread_pool_utils.hpp>
+#endif
+
+export module BS_thread_pool;
+
+#ifdef BS_THREAD_POOL_USE_STD_MODULE
+import std;
+
+extern "C++" {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
+#include <BS_thread_pool.hpp>
+#include <BS_thread_pool_utils.hpp>
+#pragma clang diagnostic pop
+}
+#endif
+
+export namespace BS {
+namespace this_thread {
+    using this_thread::get_index;
+    using this_thread::get_pool;
+    using this_thread::optional_index;
+    using this_thread::optional_pool;
+}
+
+    using BS::thread_pool;
+    using BS::multi_future;
+    using BS::signaller;
+    using BS::synced_stream;
+    using BS::timer;
+}


### PR DESCRIPTION
This PR adds C++20 module feature with optional standard library module (can be enabled via `BS_THREAD_POOL_USE_STD_MODULE` macro).

- `BS_thread_pool.cppm` module file exports symbols. Note that helper classes like `BS::this_thread::thread_info_index` are not visible to the end user.
- Do not include standard library headers if `BS_THREAD_POOL_USE_STD_MODULE` macro defined, and use `std` module instead. This can dramatically reduce the compile time.