### PR TITLE
Export wait_deadlock only if __cpp_exceptions is defined.

### DIFF
--- a/modules/BS.thread_pool.cppm
+++ b/modules/BS.thread_pool.cppm
@@ -42,7 +42,9 @@ using BS::thread_pool_native_extensions;
 using BS::thread_pool_version;
 using BS::tp;
 using BS::version;
+#ifdef __cpp_exceptions
 using BS::wait_deadlock;
+#endif
 using BS::wdc_thread_pool;
 
 #ifdef BS_THREAD_POOL_NATIVE_EXTENSIONS


### PR DESCRIPTION
As `wait_deadlock` is only defined if `__cpp_exceptions` macro defined, module also export it only if macro is defined.